### PR TITLE
docs(accounting): Updated the README documenting the expected message

### DIFF
--- a/.github/workflows/accounting-consumer-contract.yml
+++ b/.github/workflows/accounting-consumer-contract.yml
@@ -1,0 +1,59 @@
+name: Accounting Consumer Contract Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/accounting/**'
+      - '.github/workflows/accounting-consumer-contract.yml'
+  pull_request:
+    paths:
+      - 'src/accounting/**'
+      - '.github/workflows/accounting-consumer-contract.yml'
+
+jobs:
+  pact-consumer:
+    runs-on: ubuntu-latest
+    env:
+      PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_URL }}
+      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+      CONSUMER_VERSION: ${{ github.sha }}
+      CONSUMER_TAG: ${{ github.ref_name }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run consumer contract tests
+        run: dotnet test src/accounting/tests --configuration Release
+
+      - name: Publish pacts to broker
+        run: |
+          docker run --rm \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            -v "${PWD}/src/accounting/tests/pacts:/pacts" \
+            pactfoundation/pact-cli:latest \
+            broker publish /pacts \
+              --consumer-app-version "$CONSUMER_VERSION" \
+              --branch "$CONSUMER_TAG"
+
+      - name: Check can-i-deploy to production
+        run: |
+          docker run --rm \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            pactfoundation/pact-cli:latest \
+            broker can-i-deploy \
+              --pacticipant accounting-consumer \
+              --version "$CONSUMER_VERSION" \
+              --to-environment production
+
+      # TODO: deploy step goes here once can-i-deploy succeeds

--- a/src/accounting/README.md
+++ b/src/accounting/README.md
@@ -2,6 +2,69 @@
 
 This service consumes new orders from a Kafka topic.
 
+## API Contract (Kafka Message)
+
+The Accounting service expects **binary protobuf** payloads on the `orders` topic. Each message must be an `OrderResult` message defined in [`pb/demo.proto`](../../pb/demo.proto).
+
+### `OrderResult` schema (excerpt)
+
+```proto
+message OrderResult {
+  string   order_id               = 1;  // required
+  string   shipping_tracking_id   = 2;  // required
+  Money    shipping_cost          = 3;  // required
+  Address  shipping_address       = 4;  // required
+  repeated OrderItem items        = 5;  // required (must contain at least one element)
+}
+
+message OrderItem {
+  CartItem item  = 1; // required
+  Money    cost  = 2; // required
+}
+
+// Supporting messages
+message Address {
+  string street_address = 1;
+  string city           = 2;
+  string state          = 3;
+  string country        = 4;
+  string zip_code       = 5;
+}
+
+message Money {
+  string currency_code = 1; // ISO-4217 code, e.g. "USD"
+  int64  units         = 2; // whole units (dollars)
+  int32  nanos         = 3; // fractional part in nanoseconds
+}
+```
+
+### Example payload (JSON view)
+
+```jsonc
+{
+  "order_id": "2",
+  "shipping_tracking_id": "1234567890",
+  "shipping_cost": { "currency_code": "USD", "units": 100, "nanos": 0 },
+  "shipping_address": {
+    "street_address": "123 Main St",
+    "city": "Anytown",
+    "state": "CA",
+    "country": "USA",
+    "zip_code": "12345"
+  },
+  "items": [
+    {
+      "item": { "product_id": "1", "quantity": 2 },
+      "cost": { "currency_code": "USD", "units": 100, "nanos": 0 }
+    }
+  ]
+}
+```
+
+The binary representation of this JSON is produced with `proto.Marshal(orderResult)` in the **checkout** service and deserialised with `OrderResult.Parser.ParseFrom(bytes)` in the **accounting** service.
+
+If any required field is missing, the consumer logs an error and the message is skipped.
+
 ## Local Build
 
 To build the service binary, run:
@@ -26,4 +89,3 @@ To bump all dependencies run in Package manager:
 
 ```sh
 Update-Package -ProjectName Accounting
-```

--- a/src/accounting/tests/Accounting.Consumer.Tests.csproj
+++ b/src/accounting/tests/Accounting.Consumer.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Unit test & runner -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- Pact Message testing -->
+    <PackageReference Include="PactNet" Version="5.0.1" />
+
+    <!-- Logging helpers -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Accounting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/accounting/tests/ConsumerMessageContractTests.cs
+++ b/src/accounting/tests/ConsumerMessageContractTests.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using Accounting;
+using Confluent.Kafka;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oteldemo;
+using PactNet;
+using PactNet.Verifier;
+using Xunit;
+
+namespace Accounting.Tests;
+
+public class ConsumerMessageContractTests
+{
+    private const string PactDir = "pacts";
+
+    [Fact]
+    public void ProcessMessage_handles_valid_OrderResult_message()
+    {
+        // Build a sample OrderResult matching the protobuf schema
+        var sampleBytes = BuildSamplePayload();
+
+        // Configure Pact message verification
+        var pact = MessagePact.V3("accounting-consumer", "checkout-provider", cfg =>
+        {
+            cfg.PactDir(PactDir);
+        });
+
+        pact.Messages(m =>
+        {
+            m.ExpectsToReceive("a valid OrderResult message")
+             .WithMetadata(new Dictionary<string, object>
+             {
+                 { "contentType", "application/protobuf" }
+             })
+             .WithBinaryContent(sampleBytes);
+        });
+
+        pact.Verify(bytes =>
+        {
+            // Arrange a Consumer instance with a null DBContext so we skip persistence.
+            var consumer = new Consumer(NullLogger<Consumer>.Instance);
+            // set _dbContext -> null using reflection (private field)
+            typeof(Consumer)
+                .GetField("_dbContext", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(consumer, null);
+
+            // Act – invoke handler directly
+            consumer.ProcessMessage(new Message<string, byte[]> { Value = bytes });
+        });
+    }
+
+    private static byte[] BuildSamplePayload()
+    {
+        var order = new OrderResult
+        {
+            OrderId = "2",
+            ShippingTrackingId = "1234567890",
+            ShippingCost = new Money { CurrencyCode = "USD", Units = 100, Nanos = 0 },
+            ShippingAddress = new Address
+            {
+                StreetAddress = "123 Main St",
+                City = "Anytown",
+                State = "CA",
+                Country = "USA",
+                ZipCode = "12345"
+            }
+        };
+
+        order.Items.Add(new OrderItem
+        {
+            Item = new CartItem { ProductId = "1", Quantity = 2 },
+            Cost = new Money { CurrencyCode = "USD", Units = 100, Nanos = 0 }
+        });
+
+        return order.ToByteArray();
+    }
+}


### PR DESCRIPTION
…push to pact broker, also disabled other workflows for now# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
This pull request introduces consumer-driven contract testing for the Accounting service, adds documentation for the expected Kafka message schema, and updates dependencies to support the new functionality. The key changes include a GitHub Actions workflow for contract tests, a new test project with PactNet integration, and detailed schema documentation in the `README.md`.

### Consumer-driven contract testing:

* [`.github/workflows/accounting-consumer-contract.yml`](diffhunk://#diff-bfc994abf8f1ecc85718e7d4d3b901d9fe8916090f4cef3be3d6cf35fd62840bR1-R59): Added a new GitHub Actions workflow to run consumer contract tests for the Accounting service, publish pacts to the broker, and verify deployment compatibility with the production environment.
* [`src/accounting/tests/Accounting.Consumer.Tests.csproj`](diffhunk://#diff-af402b16332d6caf9873f71b6738476d4a0ecb9bcc182c3bd806b0dedc399cc4R1-R28): Created a new test project targeting `net8.0` with dependencies on `PactNet` for contract testing and `xunit` for unit testing.
* [`src/accounting/tests/ConsumerMessageContractTests.cs`](diffhunk://#diff-96f94b029428741c9ca250145d473bd353acd34cf6d7ba82ffb862c6a92a1b45R1-R78): Implemented a test to verify that the Accounting service correctly processes valid `OrderResult` messages according to the protobuf schema using PactNet's message pact functionality.

### Documentation updates:

* [`src/accounting/README.md`](diffhunk://#diff-acb7a506b7c68ea27221e7e7a489f2f32d22fcd7e31f5f1df25de2f11d34aafcR5-R67): Added a detailed description of the Kafka message schema (`OrderResult`) expected by the Accounting service, including its protobuf definition and an example payload. This ensures developers understand the contract requirements.

### Dependency updates:

* [`src/accounting/README.md`](diffhunk://#diff-acb7a506b7c68ea27221e7e7a489f2f32d22fcd7e31f5f1df25de2f11d34aafcL29): Removed an outdated reference to the `Update-Package` command in the README.
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
… payload from kafka queue for this service referencing the protbuf message objects and giving a JSON representation